### PR TITLE
orderby value incorrect for querying posts by date field

### DIFF
--- a/docs/fields/date.md
+++ b/docs/fields/date.md
@@ -114,7 +114,7 @@ Saving values in timestamp allows you to query posts with a specific order by th
 ```php
 $query = new WP_Query( [
     'post_type' => 'event',
-    'orderby'   => 'meta_value_num',
+    'orderby'   => 'meta_value',
     'meta_key'  => 'my_field_id',
     'order'     => 'ASC',
 ] );


### PR DESCRIPTION
if you order by 'meta_value_num' the order output is incorrect, for the date custom field you need to order by 'meta_value'